### PR TITLE
chore(release): v0.35 — M5 code review fixes + M6/M7 reorder

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,100 @@
+# ♊ GEMINI.md — Sentinel-Gemini
+
+Você é o **Sentinel-Gemini**, o parceiro de engenharia de alta precisão para o ecossistema Sentinel. 
+Este documento é sua diretriz mestre: define o contexto do produto, ambiente, thresholds, ferramentas e o workflow baseado em **Plan Mode** e **Agentes**.
+
+> Versão atual do agent: **v0.34** (M5 UI Alignment: Honeycomb Auto-Scaling)
+
+---
+
+## 🎯 Visão do Produto (DNA)
+
+**Sentinel é inteligência SRE/FinOps para equipes pequenas.** Times que precisam de confiabilidade e gestão de custos sem a complexidade de uma stack Prometheus/Grafana dedicada.
+
+### Princípios de Design
+- **Didático e Lean**: Cada métrica deve ser autoexplicável (tooltips ⓘ inline).
+- **Acionável**: Mostre o problema e o caminho da solução.
+- **Standalone**: Zero dependências externas (no-Prometheus).
+- **Graceful Degradation**: Análise determinística primeiro, LLM para explicação narrativa.
+- **UNMANAGED é Crítico**: Pods sem `resources.requests` são riscos de performance e custos invisíveis.
+
+---
+
+## 🌍 Contexto de Voo (Ambiente)
+
+- **Infraestrutura:** Kubernetes em Minikube (Fedora), driver KVM2, build com Podman.
+- **Namespace Principal:** `sentinel-gemini` (Agent Go + PostgreSQL).
+- **Acesso Dashboard:** `NodePort :30080` → `http://<minikube-ip>:30080` (Acesso direto sem port-forward).
+- **Timezone:** `America/Sao_Paulo` (Requer `tzdata` no Alpine e `time.Local` no Go).
+- **Persistência:** PostgreSQL (`sentinel_db`) roda como pod no cluster.
+- **Boot Time:** Cluster leva 10-15m para estabilizar. Erros iniciais de rede são `INFO`.
+- **Restarts:** Em Minikube não-persistente, contadores altos de restart são normais; foque no **Estado Atual** (`CrashLoopBackOff`, etc).
+
+---
+
+## 📊 Thresholds de Operação
+
+| Métrica              | WARNING      | CRITICAL         |
+|----------------------|--------------|------------------|
+| CPU                  | > 70%        | > 85%            |
+| Memória              | > 75%        | > 90%            |
+| Disco                | > 70%        | > 85%            |
+| Pod Pending          | > 5m         | —                |
+| Pod CrashLoopBackOff | —            | Imediato         |
+| Waste por pod        | > 60%        | —                |
+
+---
+
+## 🛠️ Workflow de Engenharia (Gemini Mode)
+
+O Gemini CLI opera em ciclos de **Pesquisa -> Estratégia -> Execução**.
+
+1.  **Plan Mode (`--plan`)**: Obrigatório para mudanças arquiteturais, novas APIs ou refatorações complexas. Crie um `PLAN.md` temporário para aprovação do usuário.
+2.  **Otimização de Custo (Model Split)**:
+    *   **Pro**: Design, Refatoração Core, Debbuging de Concorrência.
+    *   **Flash**: Boilerplate, Repositórios SQL, Testes Unitários e Docs.
+3.  **Sub-Agentes (`--agent`)**:
+    *   `codebase_investigator`: Para análise profunda de dependências e bugs raiz.
+    *   `generalist`: Para tarefas de refatoração em lote ou correções de lint em múltiplos arquivos.
+3.  **Harness de Segurança**: Todo relatório/runbook deve ser validado via `python3 tools/report_tool.py`.
+4.  **Checkpoint**: Ao final de cada sessão, atualize o `SESSION_NOTES.md` e os arquivos de memória do projeto.
+
+---
+
+## 🔧 Ferramentas e Comandos
+
+| Comando               | Descrição                                                     |
+|-----------------------|---------------------------------------------------------------|
+| `make start/stop`     | Gerenciamento do Go Agent (dentro de `agent/`).               |
+| `make logs`           | Tail dos logs em tempo real.                                  |
+| `podman build...`     | Build da imagem Docker (sempre a partir da raiz do projeto).  |
+| `generate_report`     | `python3 tools/report_tool.py --severity <SEV> --component <X> --content <MD>` |
+
+---
+
+## 📂 Memória Técnica & Descobertas
+
+- **Go Embed**: Mudanças em `agent/static/` (CSS/JS) exigem rebuild da imagem e redeploy do pod. JS agora em 7 módulos em `agent/static/js/`.
+- **Money Scale**: Em Minikube, custos são mínimos. Use `fmtMoney()` para exibir até 6 casas decimais.
+- **Node Mocking**: O agente gera pods fictícios em `mock-nodes` para facilitar testes de UI sem carga real.
+- **Auth**: `AUTH_TOKEN` sem default — agente recusa iniciar sem ele quando `AUTH_ENABLED=true`. Gerar token: `python3 -c "import secrets; print(secrets.token_hex(32))"`. Passar via `?token=` na URL ou `localStorage`. Rotacionar via `helm upgrade --set agent.auth.token=<novo>` sem rebuild.
+- **Deploy Minikube**: `http://$(minikube ip):30080/?token=<token>` — namespace `sentinel-gemini`, NodePort 30080.
+
+---
+
+## 📝 Próximos Passos (Backlog M5 - Intelligence & UI)
+
+- [x] **Modo Degradado**: Garantir que `/api/incidents` retorne análise determinística sólida sem LLM.
+- [x] **Integração Gemini**: Enriquecer incidentes com narrativa (explicar o *porquê* da falha).
+- [ ] **UI Alignment**: Estilizar pods no *honeycomb* do Node Health para refletir Datadog pods.
+- [x] **UI Detail**: Adicionar barra de "Memory Requested" no drawer global de nós (lista de todos os nós).
+- [x] **UI Pressure Indicator**: Adicionar badge "Pressure" ou borda vermelha em nós com 100% de CPU/Memoria no drawer (ex: mock-node-24/20).
+- [ ] **Online Boutique**: Testes de detecção de incidentes em lab real.
+
+---
+
+## ⚙️ Configurações de Sessão
+- **Idioma**: pt-BR.
+- **Estilo**: SRE Senior, conciso, focado em remediação.
+- **Posts**: dev.to (bilíngue EN/PT), LinkedIn (parágrafos densos, sem bullets).
+llets).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -3,7 +3,7 @@
 Você é o **Sentinel-Gemini**, o parceiro de engenharia de alta precisão para o ecossistema Sentinel. 
 Este documento é sua diretriz mestre: define o contexto do produto, ambiente, thresholds, ferramentas e o workflow baseado em **Plan Mode** e **Agentes**.
 
-> Versão atual do agent: **v0.34** (M5 UI Alignment: Honeycomb Auto-Scaling)
+> Versão atual do agent: **v0.35** (M5 code review fixes: XSS copy button, runbooks, LLM nil-pointer, pkg/llm tests)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 > Incident detection, waste analysis, cost forecasting and AI-powered explanations — no Prometheus required.
 
 <p align="center">
-  <img src="docs/screenshots/sentinel_ss_0.10.33.png" alt="Sentinel Dashboard v0.33" width="900"/>
+  <img src="docs/screenshots/sentinel_ss_0.10.34.png" alt="Sentinel Dashboard v0.34" width="900"/>
 </p>
 
-![Status](https://img.shields.io/badge/status-v0.33-brightgreen)
+![Status](https://img.shields.io/badge/status-v0.34-brightgreen)
 ![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.1-blue)
 ![Go](https://img.shields.io/badge/Go-1.23-00ADD8)
 ![Standalone](https://img.shields.io/badge/standalone-no%20Prometheus-green)
@@ -46,9 +46,9 @@ Most small engineering teams overpay for Kubernetes without knowing it. Tools li
 
 ## Screenshots
 
-| Dashboard Overview (v0.33) | Recent Events Drawer |
+| Dashboard Overview (v0.34) | Recent Events Drawer |
 |---|---|
-| ![Overview](docs/screenshots/sentinel_ss_0.10.33.png) | ![Events](docs/screenshots/sentinel_ss_0.10.20(2).png) |
+| ![Overview](docs/screenshots/sentinel_ss_0.10.34.png) | ![Events](docs/screenshots/sentinel_ss_0.10.20(2).png) |
 
 | Efficiency Tab | Waste Intelligence |
 |---|---|
@@ -382,7 +382,7 @@ Every final report passes through `harness/validador_saida.py` before being writ
 
 ## Changelog
 
-### v0.33
+### v0.34
 - **Auto-scaling Honeycomb Map** — Datadog-inspired visual density map for cluster health.
 - **Node Detail Drawer** — Individual node analysis with CPU/Memory saturation bars and pod list.
 - **Improved UX** — Back buttons for seamless navigation between node details and global lists.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
   <img src="docs/screenshots/sentinel_ss_0.10.34.png" alt="Sentinel Dashboard v0.34" width="900"/>
 </p>
 
-![Status](https://img.shields.io/badge/status-v0.34-brightgreen)
+![Status](https://img.shields.io/badge/status-v0.35-brightgreen)
 ![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.1-blue)
 ![Go](https://img.shields.io/badge/Go-1.23-00ADD8)
 ![Standalone](https://img.shields.io/badge/standalone-no%20Prometheus-green)
-![Tests](https://img.shields.io/badge/tests-56%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-37%20passing-brightgreen)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 
 ---
@@ -329,6 +329,9 @@ sentinel/
 │   │   ├── k8s/                     # Kubernetes client + Metrics API wrappers
 │   │   │   ├── k8s.go
 │   │   │   └── k8s_test.go
+│   │   ├── llm/                     # LLM provider interface + Ollama skeleton
+│   │   │   ├── client.go            # Provider interface, NewClient(), ollamaProvider
+│   │   │   └── client_test.go
 │   │   └── store/                   # PostgreSQL: schema, aggregation, retention
 │   │       ├── store.go
 │   │       └── store_test.go
@@ -382,6 +385,13 @@ Every final report passes through `harness/validador_saida.py` before being writ
 
 ## Changelog
 
+### v0.35 — M5 code review fixes
+- **Security (JS):** Copy button in Alerts drawer now uses `data-runbook` + `addEventListener` — previously the `onclick` attribute was silently stripped by DOMPurify, rendering the button non-functional.
+- **Runbooks:** `ErrImagePull` and `CreateContainerConfigError` now produce `kubectl describe pod` instead of `kubectl logs` (container never started; logs return nothing).
+- **LLM skeleton:** Fixed latent nil-pointer panic when `LLM_PROVIDER=gemini` — now correctly returns `Enabled: false` like other unimplemented providers.
+- **Tests:** Added 4 unit tests for `pkg/llm` covering all `NewClient()` branches (Go: 14 tests; harness: 23 tests; total: 37).
+- **Roadmap:** Swapped M6/M7 — Real lab/QA before docs/polish; rationale in ROADMAP.md.
+
 ### v0.34
 - **Auto-scaling Honeycomb Map** — Datadog-inspired visual density map for cluster health.
 - **Node Detail Drawer** — Individual node analysis with CPU/Memory saturation bars and pod list.
@@ -421,8 +431,8 @@ Every final report passes through `harness/validador_saida.py` before being writ
 | M3 — Deterministic incident intelligence | ✅ Done | v0.11 |
 | M4 — Critical Resilience & Security | ✅ Done | v0.12 |
 | M5 — Optional intelligence (LLM as a layer) | Partial (~65%) | v0.12 → v0.50 |
-| M6 — v1.0 preparation | Not started | v0.99 |
-| M7 — Real lab / QA / Prod-like | Not started | v1.0-rc |
+| M6 — Real lab / QA / Prod-like | Not started | v0.50 |
+| M7 — v1.0 preparation | Not started | v0.99 |
 
 See [ROADMAP.md](ROADMAP.md) for full details.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Sentinel-Gemini Roadmap — 0.x → 1.0
 
-> Last updated: 2026-04-18 | Current version: `v0.33`
+> Last updated: 2026-04-18 | Current version: `v0.34`
 
 ## Product vision
 
@@ -154,9 +154,9 @@
 | Narrative rendered in Alerts drawer when populated (collapsible "Why?" block) | ✅ Done (`v0.12`) |
 | Degraded mode: if intelligence layer unavailable, returns deterministic analysis | 🚧 In Progress |
 | Harness M5 remediation guard: block `kubectl exec`, `kubectl scale --replicas=0`, `helm uninstall`, `kubectl apply -f -`, `kubectl patch replicas:0` | ✅ Done (`v0.12`) |
-| **Honeycomb UI**: Datadog-style auto-scaling visual maps | ✅ Done (`v0.33`) |
-| **Node Detail**: Saturation bars + pod list per node | ✅ Done (`v0.33`) |
-| **UX Alignment**: Back buttons + event delegation | ✅ Done (`v0.33`) |
+| **Honeycomb UI**: Datadog-style auto-scaling visual maps | ✅ Done (`v0.34`) |
+| **Node Detail**: Saturation bars + pod list per node | ✅ Done (`v0.34`) |
+| **UX Alignment**: Back buttons + event delegation | ✅ Done (`v0.34`) |
 | Possible local model support (Ollama) | Future |
 | Automatic runbooks based on templates + variables | Pending |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Sentinel-Gemini Roadmap — 0.x → 1.0
 
-> Last updated: 2026-04-18 | Current version: `v0.34`
+> Last updated: 2026-04-20 | Current version: `v0.35`
 
 ## Product vision
 
@@ -31,8 +31,8 @@
 | M3 — Deterministic incident intelligence | ✅ Done | `v0.11` |
 | M4 — Critical Resilience & Security | ✅ Done | `v0.12` |
 | M5 — Optional intelligence | Partial (~65%) | `v0.12 → v0.50` |
-| M6 — v1.0 preparation | Not started | `v0.99` |
-| M7 — Real lab / QA / Prod-like | Not started | `v1.0-rc` |
+| M6 — Real lab / QA / Prod-like | Not started | `v0.50` |
+| M7 — v1.0 preparation | Not started | `v0.99` |
 
 ---
 
@@ -166,9 +166,29 @@
 
 ---
 
-### M6 — v1.0 preparation (`v0.99`)
+### M6 — Real lab / QA / Prod-Like (`v0.50`)
 
-**Goal:** You'd call it 1.0 without technical embarrassment.
+**Goal:** Validate Sentinel against a realistic workload before any documentation or contract is frozen. Surface gaps in the API, UX and observability that only emerge under real traffic.
+
+**Deliverables:**
+
+| Item | Status |
+|---|---|
+| Documented Online Boutique baseline (namespace `google-demo`) | Pending |
+| Controlled load (e.g. hey, k6) on microservices | Pending |
+| Burst and fault injection documented | Pending |
+| Before/after comparison in dashboard | Pending |
+| Lab incident report with generated runbook | Pending |
+
+**Done criterion:** Report comparing normal vs degraded cluster state produced by Sentinel, serving as community proof-of-concept. API and UI gaps identified for M7 stabilization.
+
+**Dependencies:** M5
+
+---
+
+### M7 — v1.0 preparation (`v0.99`)
+
+**Goal:** You'd call it 1.0 without technical embarrassment. Stabilize and document based on what M6 revealed under real load.
 
 **Deliverables:**
 
@@ -183,26 +203,6 @@
 | Integration tests for API contracts | Pending |
 
 **Done criterion:** Another developer can clone, configure and run Sentinel without help.
-
-**Dependencies:** M5
-
----
-
-### M7 — Real lab / QA / Prod-Like (`v1.0-rc`)
-
-**Goal:** Final QA validation. Shows a clear difference between a normal and a degraded cluster before 1.0 launch.
-
-**Deliverables:**
-
-| Item | Status |
-|---|---|
-| Documented Online Boutique baseline (namespace `google-demo`) | Pending |
-| Controlled load (e.g. hey, k6) on microservices | Pending |
-| Burst and fault injection documented | Pending |
-| Before/after comparison in dashboard | Pending |
-| Lab incident report with generated runbook | Pending |
-
-**Done criterion:** Report comparing normal vs degraded state produced by Sentinel, serving as proof-of-concept for the community.
 
 **Dependencies:** M6
 
@@ -221,20 +221,21 @@
 | `v0.11.3` | M4 | ✅ Resilience, PVC, Auth, CI, Cache Busting |
 | `v0.12` | M4 gaps + M5 foundation | ✅ Security fixes, Narrative hook, harness M5 guard, JS modularization |
 | `v0.23` | M5 | ✅ Honeycomb auto-scaling and dynamic packing |
-| `v0.23.x` | M5 | LLM as optional layer, degraded mode, UI details |
-| `v0.99` | M6 | Polish, docs, stable contracts |
-| `v1.0-rc` | M7 | Online Boutique lab (QA/Prod-like) |
+| `v0.34` | M5 | ✅ Deterministic runbooks + LLM provider skeleton |
+| `v0.35` | M5 | ✅ Code review fixes: copy button XSS, runbooks, nil-pointer, pkg/llm tests |
+| `v0.50` | M6 | Online Boutique lab (QA/Prod-like) — validate before stabilizing |
+| `v0.99` | M7 | Polish, docs, stable contracts |
 
 ---
 
 ## Backlog by priority
 
-### High priority (v0.23+)
-- M7: Online Boutique lab: baseline + load + comparison
+### High priority (v0.50)
+- M6: Online Boutique lab: baseline + load + comparison
 
-### Medium priority (v0.1.x)
+### Medium priority (v0.50+)
 - CrashLoop pod + CPU correlation (refinamento)
-- M6: API stability & full OpenAPI coverage
+- M7: API stability & full OpenAPI coverage (after M6 reveals gaps)
 
 ### Low priority / future
 - Multi-cluster (post-1.0)
@@ -258,10 +259,3 @@
 - If the dashboard fails, the API must still be usable
 - If the cluster changes, the contracts must hold
 - If the project grows, the core must not lose simplicity
-ject grows, the core must not lose simplicity
-simplicity
-ll be usable
-- If the cluster changes, the contracts must hold
-- If the project grows, the core must not lose simplicity
-ject grows, the core must not lose simplicity
-simplicity

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,16 +149,16 @@
 
 | Item | Status |
 |---|---|
-| `/incident` consumes deterministic `/api/incidents` first | 🚧 In Progress |
+| `/incident` consumes deterministic `/api/incidents` first | ✅ Done |
 | `Narrative string` field in `Incident` struct (`omitempty`, backward-compatible) | ✅ Done (`v0.12`) |
 | Narrative rendered in Alerts drawer when populated (collapsible "Why?" block) | ✅ Done (`v0.12`) |
-| Degraded mode: if intelligence layer unavailable, returns deterministic analysis | 🚧 In Progress |
+| Degraded mode: if intelligence layer unavailable, returns deterministic analysis | ✅ Done |
 | Harness M5 remediation guard: block `kubectl exec`, `kubectl scale --replicas=0`, `helm uninstall`, `kubectl apply -f -`, `kubectl patch replicas:0` | ✅ Done (`v0.12`) |
 | **Honeycomb UI**: Datadog-style auto-scaling visual maps | ✅ Done (`v0.34`) |
 | **Node Detail**: Saturation bars + pod list per node | ✅ Done (`v0.34`) |
 | **UX Alignment**: Back buttons + event delegation | ✅ Done (`v0.34`) |
 | Possible local model support (Ollama) | Future |
-| Automatic runbooks based on templates + variables | Pending |
+| Automatic runbooks based on templates + variables | ✅ Done |
 
 **Done criterion:** `/incident` works without external models and produces usable diagnosis with a visual-first UI that scales.
 
@@ -230,8 +230,6 @@
 ## Backlog by priority
 
 ### High priority (v0.23+)
-- M5: `/incident` consumindo dados determinísticos da `/api/incidents` (Modo Degradado)
-- M5: UI: Add "Memory Requested" bar to global node list drawer
 - M7: Online Boutique lab: baseline + load + comparison
 
 ### Medium priority (v0.1.x)
@@ -258,6 +256,11 @@
 
 - If the LLM goes down, Sentinel stays useful
 - If the dashboard fails, the API must still be usable
+- If the cluster changes, the contracts must hold
+- If the project grows, the core must not lose simplicity
+ject grows, the core must not lose simplicity
+simplicity
+ll be usable
 - If the cluster changes, the contracts must hold
 - If the project grows, the core must not lose simplicity
 ject grows, the core must not lose simplicity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We aim to acknowledge reports within 48 hours and release a fix within 14 days d
 
 | Version | Supported |
 |---|---|
-| `v0.33` (current) | ✅ Yes |
+| `v0.34` (current) | ✅ Yes |
 | `v0.12.x` | ✅ Yes |
 | `< v0.12` | ❌ No |
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -31,7 +31,7 @@ var (
 	usdPerGbHour   float64
 )
 
-const agentVersion = "0.33"
+const agentVersion = "0.34"
 const collectorStaleThreshold = 30 * time.Second
 
 var (

--- a/agent/main.go
+++ b/agent/main.go
@@ -31,7 +31,7 @@ var (
 	usdPerGbHour   float64
 )
 
-const agentVersion = "0.34"
+const agentVersion = "0.35"
 const collectorStaleThreshold = 30 * time.Second
 
 var (

--- a/agent/pkg/api/api_handlers.go
+++ b/agent/pkg/api/api_handlers.go
@@ -943,6 +943,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 				Type:      "Pending",
 				Severity:  "WARNING",
 				Message:   fmt.Sprintf("Pod stuck in Pending for %s", ageStr),
+				Narrative: "Pod aguardando agendamento. Causas comuns: falta de recursos nos nós, seletores de nós (labels) incompatíveis ou falha na montagem de volumes (PVC).",
 				Age:       ageStr,
 			})
 			continue
@@ -956,6 +957,11 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 			if cs.State.Waiting != nil {
 				reason := cs.State.Waiting.Reason
 				if reason == "CrashLoopBackOff" || reason == "CreateContainerConfigError" || reason == "ErrImagePull" {
+					narrative := "Falha ao iniciar o container. Verifique os logs para erros fatais ou configurações ausentes."
+					if reason == "ErrImagePull" {
+						narrative = "O Kubernetes não conseguiu baixar a imagem. Verifique se o nome da imagem está correto e se o cluster tem permissão de acesso ao registro."
+					}
+
 					if reason == "CrashLoopBackOff" {
 						crashLoopFound = true
 						crashLoopMsg = fmt.Sprintf("Container %s in %s", cs.Name, reason)
@@ -966,6 +972,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 							Type:      reason,
 							Severity:  "CRITICAL",
 							Message:   fmt.Sprintf("Container %s in %s", cs.Name, reason),
+							Narrative: narrative,
 							Age:       ageStr,
 						})
 					}
@@ -979,6 +986,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "OOMKilled",
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("Container %s OOMKilled", cs.Name),
+					Narrative: "O container foi terminado por exceder o limite de memória. Se recorrente, aumente o resources.limits.memory.",
 					Age:       ageStr,
 				})
 			}
@@ -986,6 +994,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 
 		// Correlation: CrashLoop + CPU
 		if crashLoopFound {
+			narrative := "O container está falhando consecutivamente. Verifique os logs para erros fatais da aplicação ou configurações ausentes (env vars, secrets)."
 			if cpuPct >= a.Thresholds.CPU.Warning {
 				incs = append(incs, Incident{
 					PodName:   p.Name,
@@ -993,6 +1002,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "CrashLoopCpuThrottling",
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("%s correlated with High CPU (%.1f%%)", crashLoopMsg, cpuPct),
+					Narrative: "O container está em CrashLoop e consumindo CPU excessiva durante o boot. Isso pode indicar um loop infinito no código de inicialização.",
 					Age:       ageStr,
 				})
 			} else if a.Thresholds.Pods.CrashLoopCritical {
@@ -1002,6 +1012,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "CrashLoopBackOff",
 					Severity:  "CRITICAL",
 					Message:   crashLoopMsg,
+					Narrative: narrative,
 					Age:       ageStr,
 				})
 			} else {
@@ -1011,6 +1022,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "CrashLoopBackOff",
 					Severity:  "WARNING",
 					Message:   crashLoopMsg,
+					Narrative: narrative,
 					Age:       ageStr,
 				})
 			}
@@ -1026,15 +1038,18 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "HighCPU",
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("CPU usage at %.1f%% of LIMIT (danger of throttling)", cpuLimPct),
+					Narrative: "Uso de CPU atingiu o limite configurado. Isso causa throttling severo e degradação de performance. Aumente o limite de CPU.",
 					Age:       ageStr,
 				})
 			} else if cpuPct >= a.Thresholds.CPU.Warning {
 				// Above request is always a warning, but only critical if it hits limit or is extremely high
 				sev := "WARNING"
 				msg := fmt.Sprintf("CPU usage at %.1f%% of request", cpuPct)
+				narrative := "O uso de CPU está acima da reserva solicitada. Isso pode causar latência se outros pods no mesmo nó também demandarem recursos."
 				if cpuPct > 200 {
 					sev = "CRITICAL" // Extreme case, probably misconfigured
 					msg = fmt.Sprintf("CPU usage at %.1f%% of request (Extreme over-usage)", cpuPct)
+					narrative = "O uso de CPU está drasticamente acima da reserva. Risco alto de instabilidade. Revise o dimensionamento do pod."
 				}
 				incs = append(incs, Incident{
 					PodName:   p.Name,
@@ -1042,6 +1057,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "HighCPU",
 					Severity:  sev,
 					Message:   msg,
+					Narrative: narrative,
 					Age:       ageStr,
 				})
 			}
@@ -1054,17 +1070,17 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "HighMemory",
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("Memory usage at %.1f%% of LIMIT (danger of OOMKill)", memLimPct),
+					Narrative: "Uso de memória próximo ao limite fatal. O container corre risco iminente de OOMKill. Aumente o limite de memória imediatamente.",
 					Age:       ageStr,
 				})
 			} else if memPct >= a.Thresholds.Memory.Warning {
 				sev := "WARNING"
 				msg := fmt.Sprintf("Memory usage at %.1f%% of request", memPct)
-				// If usage > 100% of request, it's a warning.
-				// It only becomes CRITICAL if it's near limit (handled above)
-				// or if it's ridiculously high relative to request and no limit is set.
+				narrative := "Uso de memória acima da reserva solicitada. Risco de expulsão (eviction) pelo Kubelet se o nó ficar sem memória livre."
 				if st.MemLimit == 0 && memPct > 250 {
 					sev = "CRITICAL"
 					msg = fmt.Sprintf("Memory usage at %.1f%% of request (No limit set, risk of eviction)", memPct)
+					narrative = "O pod não possui limite de memória e está consumindo muito além da reserva. Isso ameaça a estabilidade de outros pods no nó."
 				}
 
 				incs = append(incs, Incident{
@@ -1073,6 +1089,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Type:      "HighMemory",
 					Severity:  sev,
 					Message:   msg,
+					Narrative: narrative,
 					Age:       ageStr,
 				})
 			}
@@ -1092,6 +1109,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 				Type:      "ResourceWaste",
 				Severity:  sev,
 				Message:   s.Opportunity,
+				Narrative: "Esta carga está superprovisionada. Reduzir as reservas de recursos para patamares mais próximos do uso real pode gerar economia significativa.",
 				Age:       "-",
 				IsWaste:   true,
 			})

--- a/agent/pkg/api/api_handlers.go
+++ b/agent/pkg/api/api_handlers.go
@@ -944,6 +944,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 				Severity:  "WARNING",
 				Message:   fmt.Sprintf("Pod stuck in Pending for %s", ageStr),
 				Narrative: "Pod aguardando agendamento. Causas comuns: falta de recursos nos nós, seletores de nós (labels) incompatíveis ou falha na montagem de volumes (PVC).",
+				Runbook:   fmt.Sprintf("kubectl describe pod %s -n %s", p.Name, p.Namespace),
 				Age:       ageStr,
 			})
 			continue
@@ -973,6 +974,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 							Severity:  "CRITICAL",
 							Message:   fmt.Sprintf("Container %s in %s", cs.Name, reason),
 							Narrative: narrative,
+							Runbook:   fmt.Sprintf("kubectl logs pod/%s -c %s -n %s", p.Name, cs.Name, p.Namespace),
 							Age:       ageStr,
 						})
 					}
@@ -987,6 +989,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("Container %s OOMKilled", cs.Name),
 					Narrative: "O container foi terminado por exceder o limite de memória. Se recorrente, aumente o resources.limits.memory.",
+					Runbook:   fmt.Sprintf("kubectl describe pod %s -n %s", p.Name, p.Namespace),
 					Age:       ageStr,
 				})
 			}
@@ -995,6 +998,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 		// Correlation: CrashLoop + CPU
 		if crashLoopFound {
 			narrative := "O container está falhando consecutivamente. Verifique os logs para erros fatais da aplicação ou configurações ausentes (env vars, secrets)."
+			runbook := fmt.Sprintf("kubectl logs pod/%s -n %s --previous", p.Name, p.Namespace)
 			if cpuPct >= a.Thresholds.CPU.Warning {
 				incs = append(incs, Incident{
 					PodName:   p.Name,
@@ -1003,6 +1007,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("%s correlated with High CPU (%.1f%%)", crashLoopMsg, cpuPct),
 					Narrative: "O container está em CrashLoop e consumindo CPU excessiva durante o boot. Isso pode indicar um loop infinito no código de inicialização.",
+					Runbook:   runbook,
 					Age:       ageStr,
 				})
 			} else if a.Thresholds.Pods.CrashLoopCritical {
@@ -1013,6 +1018,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "CRITICAL",
 					Message:   crashLoopMsg,
 					Narrative: narrative,
+					Runbook:   runbook,
 					Age:       ageStr,
 				})
 			} else {
@@ -1023,6 +1029,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "WARNING",
 					Message:   crashLoopMsg,
 					Narrative: narrative,
+					Runbook:   runbook,
 					Age:       ageStr,
 				})
 			}
@@ -1039,6 +1046,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("CPU usage at %.1f%% of LIMIT (danger of throttling)", cpuLimPct),
 					Narrative: "Uso de CPU atingiu o limite configurado. Isso causa throttling severo e degradação de performance. Aumente o limite de CPU.",
+					Runbook:   fmt.Sprintf("kubectl top pod %s -n %s", p.Name, p.Namespace),
 					Age:       ageStr,
 				})
 			} else if cpuPct >= a.Thresholds.CPU.Warning {
@@ -1058,6 +1066,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  sev,
 					Message:   msg,
 					Narrative: narrative,
+					Runbook:   fmt.Sprintf("kubectl top pod %s -n %s", p.Name, p.Namespace),
 					Age:       ageStr,
 				})
 			}
@@ -1071,6 +1080,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  "CRITICAL",
 					Message:   fmt.Sprintf("Memory usage at %.1f%% of LIMIT (danger of OOMKill)", memLimPct),
 					Narrative: "Uso de memória próximo ao limite fatal. O container corre risco iminente de OOMKill. Aumente o limite de memória imediatamente.",
+					Runbook:   fmt.Sprintf("kubectl top pod %s -n %s", p.Name, p.Namespace),
 					Age:       ageStr,
 				})
 			} else if memPct >= a.Thresholds.Memory.Warning {
@@ -1090,6 +1100,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					Severity:  sev,
 					Message:   msg,
 					Narrative: narrative,
+					Runbook:   fmt.Sprintf("kubectl top pod %s -n %s", p.Name, p.Namespace),
 					Age:       ageStr,
 				})
 			}
@@ -1110,6 +1121,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 				Severity:  sev,
 				Message:   s.Opportunity,
 				Narrative: "Esta carga está superprovisionada. Reduzir as reservas de recursos para patamares mais próximos do uso real pode gerar economia significativa.",
+				Runbook:   fmt.Sprintf("kubectl get pod %s -n %s -o yaml", s.Name, s.Namespace),
 				Age:       "-",
 				IsWaste:   true,
 			})

--- a/agent/pkg/api/api_handlers.go
+++ b/agent/pkg/api/api_handlers.go
@@ -966,7 +966,7 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 					if reason == "CrashLoopBackOff" {
 						crashLoopFound = true
 						crashLoopMsg = fmt.Sprintf("Container %s in %s", cs.Name, reason)
-					} else {
+					} else if reason == "ErrImagePull" {
 						incs = append(incs, Incident{
 							PodName:   p.Name,
 							Namespace: p.Namespace,
@@ -974,7 +974,19 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 							Severity:  "CRITICAL",
 							Message:   fmt.Sprintf("Container %s in %s", cs.Name, reason),
 							Narrative: narrative,
-							Runbook:   fmt.Sprintf("kubectl logs pod/%s -c %s -n %s", p.Name, cs.Name, p.Namespace),
+							Runbook:   fmt.Sprintf("kubectl describe pod %s -n %s", p.Name, p.Namespace),
+							Age:       ageStr,
+						})
+					} else {
+						// CreateContainerConfigError and other init failures
+						incs = append(incs, Incident{
+							PodName:   p.Name,
+							Namespace: p.Namespace,
+							Type:      reason,
+							Severity:  "CRITICAL",
+							Message:   fmt.Sprintf("Container %s in %s", cs.Name, reason),
+							Narrative: narrative,
+							Runbook:   fmt.Sprintf("kubectl describe pod %s -n %s", p.Name, p.Namespace),
 							Age:       ageStr,
 						})
 					}
@@ -1132,6 +1144,11 @@ func (a *API) handleIncidents(w http.ResponseWriter, r *http.Request) {
 		incs = []Incident{}
 	}
 
+	// TODO(arch): LLM enrichment must NOT be called synchronously here.
+	// Calling GenerateEnrichment() inline would block this handler goroutine for
+	// the full LLM round-trip (potentially 5-30s on Ollama), degrading all
+	// concurrent dashboard requests. The correct pattern: enrich incidents in a
+	// background goroutine during the collector cycle and cache the result here.
 	slog.Debug("incidents computed", "component", "http", "count", len(incs))
 	json.NewEncoder(w).Encode(incs)
 }

--- a/agent/pkg/api/types.go
+++ b/agent/pkg/api/types.go
@@ -150,7 +150,7 @@ type Incident struct {
 	Type      string `json:"type"`
 	Severity  string `json:"severity"`
 	Message   string `json:"message"`
-	Narrative string `json:"narrative,omitempty"` // LLM-generated explanation; empty until M5 intelligence layer is active
+	Narrative string `json:"narrative,omitempty"` // SRE narrative; deterministic in M5, LLM-enriched when provider is active
 	Runbook   string `json:"runbook,omitempty"`   // Remediation commands (deterministic or LLM-generated)
 	Age       string `json:"age"`
 	IsWaste   bool   `json:"isWaste"`

--- a/agent/pkg/api/types.go
+++ b/agent/pkg/api/types.go
@@ -151,6 +151,7 @@ type Incident struct {
 	Severity  string `json:"severity"`
 	Message   string `json:"message"`
 	Narrative string `json:"narrative,omitempty"` // LLM-generated explanation; empty until M5 intelligence layer is active
+	Runbook   string `json:"runbook,omitempty"`   // Remediation commands (deterministic or LLM-generated)
 	Age       string `json:"age"`
 	IsWaste   bool   `json:"isWaste"`
 }

--- a/agent/pkg/llm/client.go
+++ b/agent/pkg/llm/client.go
@@ -32,6 +32,8 @@ func NewClient() *Client {
 		p = newOllamaProvider()
 	case "gemini":
 		// p = newGeminiProvider() // Future implementation
+		slog.Warn("Gemini provider not yet implemented, falling back to deterministic mode", "provider", providerName)
+		return &Client{Enabled: false}
 	default:
 		slog.Warn("Unknown LLM provider, falling back to deterministic mode", "provider", providerName)
 		return &Client{Enabled: false}

--- a/agent/pkg/llm/client.go
+++ b/agent/pkg/llm/client.go
@@ -1,0 +1,76 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// Provider defines the interface for LLM integrations
+type Provider interface {
+	GenerateEnrichment(ctx context.Context, incidentJSON string) (narrative string, runbook string, err error)
+}
+
+// Client manages the active LLM provider for the Sentinel Agent
+type Client struct {
+	ActiveProvider Provider
+	Enabled        bool
+}
+
+// NewClient initializes the LLM client based on environment variables
+func NewClient() *Client {
+	providerName := os.Getenv("LLM_PROVIDER")
+	if providerName == "" {
+		return &Client{Enabled: false}
+	}
+
+	slog.Info("LLM provider configured", "provider", providerName)
+
+	var p Provider
+	switch providerName {
+	case "ollama":
+		p = newOllamaProvider()
+	case "gemini":
+		// p = newGeminiProvider() // Future implementation
+	default:
+		slog.Warn("Unknown LLM provider, falling back to deterministic mode", "provider", providerName)
+		return &Client{Enabled: false}
+	}
+
+	return &Client{
+		ActiveProvider: p,
+		Enabled:        true,
+	}
+}
+
+// --- Ollama Implementation Skeleton ---
+
+type ollamaProvider struct {
+	Endpoint string
+	Model    string
+}
+
+func newOllamaProvider() *ollamaProvider {
+	endpoint := os.Getenv("OLLAMA_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://ollama.default.svc.cluster.local:11434"
+	}
+	model := os.Getenv("OLLAMA_MODEL")
+	if model == "" {
+		model = "llama3"
+	}
+	return &ollamaProvider{
+		Endpoint: endpoint,
+		Model:    model,
+	}
+}
+
+func (o *ollamaProvider) GenerateEnrichment(ctx context.Context, incidentJSON string) (string, string, error) {
+	// TODO: Implement HTTP POST to Ollama API with tight timeout
+	// Example logic:
+	// 1. Create JSON payload for Ollama with the incident data
+	// 2. http.NewRequestWithContext(ctx, "POST", o.Endpoint+"/api/generate", body)
+	// 3. Parse response and extract narrative + runbook
+	// 4. Return
+	return "", "", nil
+}

--- a/agent/pkg/llm/client_test.go
+++ b/agent/pkg/llm/client_test.go
@@ -1,0 +1,49 @@
+package llm
+
+import "testing"
+
+func TestNewClient_NoProvider(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "")
+	c := NewClient()
+	if c.Enabled {
+		t.Error("expected Enabled=false when LLM_PROVIDER is not set")
+	}
+	if c.ActiveProvider != nil {
+		t.Error("expected ActiveProvider=nil when LLM_PROVIDER is not set")
+	}
+}
+
+func TestNewClient_UnknownProvider(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "openai")
+	c := NewClient()
+	if c.Enabled {
+		t.Error("expected Enabled=false for unknown provider")
+	}
+	if c.ActiveProvider != nil {
+		t.Error("expected ActiveProvider=nil for unknown provider")
+	}
+}
+
+func TestNewClient_GeminiNotImplemented(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "gemini")
+	c := NewClient()
+	if c.Enabled {
+		t.Error("expected Enabled=false for gemini (not yet implemented)")
+	}
+	if c.ActiveProvider != nil {
+		t.Error("expected ActiveProvider=nil for gemini (not yet implemented)")
+	}
+}
+
+func TestNewClient_OllamaProvider(t *testing.T) {
+	t.Setenv("LLM_PROVIDER", "ollama")
+	t.Setenv("OLLAMA_ENDPOINT", "http://localhost:11434")
+	t.Setenv("OLLAMA_MODEL", "llama3")
+	c := NewClient()
+	if !c.Enabled {
+		t.Error("expected Enabled=true for ollama provider")
+	}
+	if c.ActiveProvider == nil {
+		t.Error("expected ActiveProvider!=nil for ollama provider")
+	}
+}

--- a/agent/static/dashboard.html
+++ b/agent/static/dashboard.html
@@ -8,7 +8,7 @@
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/static/dashboard.css?v=0.33">
+<link rel="stylesheet" href="/static/dashboard.css?v=0.34">
 </head>
 <body>
 
@@ -403,13 +403,13 @@
   <div class="gl-row" style="border-bottom:none"><span style="color:var(--text-dim);font-weight:600;min-width:80px">±1.5σ</span><span class="gl-desc">95% confidence band &mdash; statistical margin. Real value likely falls within this range.</span></div>
 </div>
 
-<script src="/static/js/01-init.js?v=0.33"></script>
-<script src="/static/js/02-charts.js?v=0.33"></script>
-<script src="/static/js/03-namespace.js?v=0.33"></script>
-<script src="/static/js/04-overview.js?v=0.33"></script>
-<script src="/static/js/05-workloads.js?v=0.33"></script>
-<script src="/static/js/06-drawers.js?v=0.33"></script>
-<script src="/static/js/07-polling.js?v=0.33"></script>
+<script src="/static/js/01-init.js?v=0.34"></script>
+<script src="/static/js/02-charts.js?v=0.34"></script>
+<script src="/static/js/03-namespace.js?v=0.34"></script>
+<script src="/static/js/04-overview.js?v=0.34"></script>
+<script src="/static/js/05-workloads.js?v=0.34"></script>
+<script src="/static/js/06-drawers.js?v=0.34"></script>
+<script src="/static/js/07-polling.js?v=0.34"></script>
 <!-- FOOTER -->
 <div style="background:#090c12;border-top:1px solid var(--border);padding:5px 20px;display:flex;align-items:center;justify-content:space-between;font-size:.68em;color:var(--text-dim)">
   <span>Built with <span style="color:#fff">OpenCode</span> + <span style="color:#00ADD8">Go</span> + <span style="color:#F7DF1E">JS</span> &bull; Kubernetes Dashboard</span>

--- a/agent/static/js/06-drawers.js
+++ b/agent/static/js/06-drawers.js
@@ -504,7 +504,7 @@ async function renderAlertsDrawer() {
       var msg = esc(inc.message || '');
       if (inc.age) msg += ' <span style="opacity:0.7">(' + esc(inc.age) + ')</span>';
       if (inc.narrative) msg += '<div style="font-size:.74em;color:var(--text-dim);margin-top:6px;font-style:italic;border-left:2px solid var(--orange);padding-left:8px">' + esc(inc.narrative) + '</div>';
-      if (inc.runbook) msg += '<div style="margin-top:8px;background:rgba(0,0,0,0.25);border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px 10px;font-family:monospace;font-size:0.75em;color:var(--text-bright);display:flex;justify-content:space-between;align-items:center"><span style="overflow-x:auto;white-space:nowrap;padding-right:10px">' + esc(inc.runbook) + '</span><button onclick="navigator.clipboard.writeText(\'' + esc(inc.runbook).replace(/'/g, "\\'") + '\');this.innerHTML=\'Copied!\';setTimeout(()=>this.innerHTML=\'Copy\',2000)" style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:var(--text-dim);border-radius:3px;padding:2px 6px;cursor:pointer;font-size:0.9em">Copy</button></div>';
+      if (inc.runbook) msg += '<div style="margin-top:8px;background:rgba(0,0,0,0.25);border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px 10px;font-family:monospace;font-size:0.75em;color:var(--text-bright);display:flex;justify-content:space-between;align-items:center"><span style="overflow-x:auto;white-space:nowrap;padding-right:10px">' + esc(inc.runbook) + '</span><button class="runbook-copy-btn" data-runbook="' + esc(inc.runbook) + '" style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:var(--text-dim);border-radius:3px;padding:2px 6px;cursor:pointer;font-size:0.9em;flex-shrink:0">Copy</button></div>';
 
       alertItems += alertCard(inc.podName || inc.name || '--', inc.namespace, typeStr, cls, color, icon, msg);
     });
@@ -514,6 +514,7 @@ async function renderAlertsDrawer() {
     }
 
     drawerHTML(alertInfoCard + statsHtml + '<div style="display:flex;flex-direction:column;gap:8px">' + alertItems + '</div>');
+    attachRunbookCopyHandlers();
 
     document.getElementById('alert-info-btn').addEventListener('click', function() {
       var c = document.getElementById('alert-info-card');
@@ -1111,6 +1112,20 @@ async function renderMemDrawer() {
     });
     attachSortHandlers('', renderMemDrawer);
   } catch(e) { drawerHTML('<div style="color:var(--red);padding:20px">Error: ' + esc(e.message) + '</div>'); }
+}
+
+// ─── Helper: runbook copy buttons ────────────────────────────────────────────
+function attachRunbookCopyHandlers() {
+  document.querySelectorAll('#drawer-body .runbook-copy-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var text = btn.dataset.runbook;
+      if (!text) return;
+      navigator.clipboard.writeText(text).then(function() {
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+      });
+    });
+  });
 }
 
 // ─── Helper: dstat card ───────────────────────────────────────────────────────

--- a/agent/static/js/06-drawers.js
+++ b/agent/static/js/06-drawers.js
@@ -504,6 +504,7 @@ async function renderAlertsDrawer() {
       var msg = esc(inc.message || '');
       if (inc.age) msg += ' <span style="opacity:0.7">(' + esc(inc.age) + ')</span>';
       if (inc.narrative) msg += '<div style="font-size:.74em;color:var(--text-dim);margin-top:6px;font-style:italic;border-left:2px solid var(--orange);padding-left:8px">' + esc(inc.narrative) + '</div>';
+      if (inc.runbook) msg += '<div style="margin-top:8px;background:rgba(0,0,0,0.25);border:1px solid rgba(255,255,255,0.1);border-radius:4px;padding:6px 10px;font-family:monospace;font-size:0.75em;color:var(--text-bright);display:flex;justify-content:space-between;align-items:center"><span style="overflow-x:auto;white-space:nowrap;padding-right:10px">' + esc(inc.runbook) + '</span><button onclick="navigator.clipboard.writeText(\'' + esc(inc.runbook).replace(/'/g, "\\'") + '\');this.innerHTML=\'Copied!\';setTimeout(()=>this.innerHTML=\'Copy\',2000)" style="background:transparent;border:1px solid rgba(255,255,255,0.2);color:var(--text-dim);border-radius:3px;padding:2px 6px;cursor:pointer;font-size:0.9em">Copy</button></div>';
 
       alertItems += alertCard(inc.podName || inc.name || '--', inc.namespace, typeStr, cls, color, icon, msg);
     });

--- a/agent/static/js/06-drawers.js
+++ b/agent/static/js/06-drawers.js
@@ -242,13 +242,26 @@ async function renderNodeDrawer() {
          displayPods = mData.filter(function(p) { return p.nodeName === focusNode; });
       }
     } else {
-      statsHtml = '<div class="drawer-stats">' +
+      var clusterMemSat = s.memAllocatable > 0 ? (s.memRequested / s.memAllocatable * 100) : 0;
+      var clusterCpuSat = s.cpuAllocatable > 0 ? (s.cpuRequested / s.cpuAllocatable * 100) : 0;
+
+      statsHtml = '<div class="drawer-stats" style="margin-bottom:20px">' +
         dstat('Total Nodes', nodes.length, 'var(--cyan)') +
         dstat('Total Pods', totalPods, 'var(--green)') +
         dstat('CPU Requested', s.cpuRequested + 'm', 'var(--orange)') +
         dstat('CPU Allocatable', s.cpuAllocatable + 'm', 'var(--text-bright)') +
         dstat('Memory Requested', s.memRequested + 'Mi', 'var(--purple)') +
         dstat('Efficiency', s.efficiency.toFixed(1) + '%', s.efficiency > 85 ? 'var(--red)' : s.efficiency > 70 ? 'var(--orange)' : 'var(--cyan)') +
+      '</div>' +
+      '<div style="margin-bottom:24px;display:flex;flex-direction:column;gap:12px;background:var(--surface);padding:16px;border-radius:6px;border:1px solid var(--border)">' +
+        '<div class="pod-detail-row" style="border:none;padding:0;margin:0"><span class="pod-detail-label" style="width:140px;color:var(--text-dim);font-size:.75em;text-transform:uppercase;letter-spacing:1px">Cluster CPU Reservation</span>' +
+          '<div class="pod-detail-bar" style="max-width:300px;flex-grow:1;height:8px;background:rgba(255,255,255,.12)"><div class="pod-detail-fill" style="width:' + Math.min(clusterCpuSat,100).toFixed(1) + '%;background:' + (clusterCpuSat > 85 ? 'var(--red)' : clusterCpuSat > 70 ? 'var(--orange)' : 'var(--cyan)') + '"></div></div>' +
+          '<span class="mono" style="margin-left:12px;font-size:0.9em;color:var(--text-bright)">' + clusterCpuSat.toFixed(1) + '%</span>' +
+        '</div>' +
+        '<div class="pod-detail-row" style="border:none;padding:0;margin:0"><span class="pod-detail-label" style="width:140px;color:var(--text-dim);font-size:.75em;text-transform:uppercase;letter-spacing:1px">Cluster Mem Reservation</span>' +
+          '<div class="pod-detail-bar" style="max-width:300px;flex-grow:1;height:8px;background:rgba(255,255,255,.12)"><div class="pod-detail-fill" style="width:' + Math.min(clusterMemSat,100).toFixed(1) + '%;background:var(--purple)"></div></div>' +
+          '<span class="mono" style="margin-left:12px;font-size:0.9em;color:var(--text-bright)">' + clusterMemSat.toFixed(1) + '%</span>' +
+        '</div>' +
       '</div>';
 
       nodeCards = nodes.slice().sort(function(a,b){
@@ -259,13 +272,19 @@ async function renderNodeDrawer() {
         var isOk = n.status === 'Running';
         var nCpuSat = n.cpuAllocatable > 0 ? (n.cpuRequested / n.cpuAllocatable * 100) : 0;
         var nMemSat = n.memAllocatable > 0 ? (n.memRequested / n.memAllocatable * 100) : 0;
+        var hasPressure = nCpuSat >= 100 || nMemSat >= 100;
         var cpuBarColor = nCpuSat > 85 ? 'var(--red)' : nCpuSat > 70 ? 'var(--orange)' : 'var(--cyan)';
         var memBarColor = nMemSat > 90 ? 'var(--red)' : nMemSat > 75 ? 'var(--orange)' : 'var(--purple)';
-        return '<div class="pod-detail-card node-card-clickable" data-node="' + esc(n.name) + '" style="cursor:pointer">' +
+        
+        var cardStyle = 'cursor:pointer';
+        if (hasPressure) cardStyle += ';border:1px solid var(--red);background:rgba(220,38,38,0.05)';
+
+        return '<div class="pod-detail-card node-card-clickable" data-node="' + esc(n.name) + '" style="' + cardStyle + '">' +
           '<div class="pod-detail-row">' +
             '<span class="pod-detail-label">Node</span>' +
             '<span class="pod-detail-val" style="color:var(--cyan)">' + esc(n.name) + '</span>' +
             '<span class="badge ' + (isOk ? 'b-ok' : 'b-crit') + '" style="font-size:.7em;margin-left:8px">' + (isOk ? 'Ready' : 'NotReady') + '</span>' +
+            (hasPressure ? '<span class="badge b-crit" style="font-size:.7em;margin-left:8px">PRESSURE</span>' : '') +
             '<span style="color:var(--text-dim);font-size:.78em;margin-left:auto">' + (n.podCount || 0) + ' pods</span>' +
           '</div>' +
           '<div class="pod-detail-row" style="align-items:center">' +


### PR DESCRIPTION
## Summary

- **Fix nil-pointer panic** em `pkg/llm/client.go`: `LLM_PROVIDER=gemini` retornava `Enabled:true` com `ActiveProvider:nil` — latent panic na primeira chamada ao provider
- **Fix Copy button** em `06-drawers.js`: `onclick` inline era removido silenciosamente pelo DOMPurify; refatorado para `data-runbook` + `addEventListener`
- **Fix runbooks** para `ErrImagePull` e `CreateContainerConfigError`: trocado `kubectl logs` (inútil, container nunca iniciou) por `kubectl describe pod`
- **4 novos testes** para `pkg/llm` cobrindo todos os branches de `NewClient()` — incluindo o teste que teria capturado o nil-pointer acima
- **Roadmap M6/M7 reordenados**: Real lab/QA (Online Boutique) → M6 (`v0.50`) antes de docs/polish → M7 (`v0.99`); backlog já listava o lab como HIGH priority enquanto a ordem original dizia o contrário
- **README + GEMINI.md**: versão `v0.35`, badge de testes corrigido (37 = 14 Go + 23 harness), `pkg/llm/` adicionado na estrutura, changelog

## Test plan

- [x] `go build ./...` — sem erros
- [x] `go test ./...` — 14/14 passando (inclui 4 novos testes `pkg/llm`)
- [x] `python3 harness/test_validador_saida.py` — 23/23 passando
- [x] `helm lint helm/sentinel` — sem warnings
- [x] Deploy Minikube revision 13 — `/health` retorna `version: 0.35`, status `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)