### PR TITLE
chore(release): align version to v1.0.0-rc.2

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,4 +1,4 @@
-# Plano Step By Step: Correcoes Pos-Code Review para v1.0-rc2
+# Plano Step By Step: Correcoes Pos-Code Review para v1.0.0-rc.2
 
 ## Summary
 
@@ -19,17 +19,17 @@ Decisoes fechadas:
 2. Docs/runtime contract
 - Corrigir referencias de setup que apontam para `agent/.env.example`; a fonte real e `.env.example` na raiz.
 - Remover ou corrigir referencias a `make start`, `make stop` e `make logs`; o `agent/Makefile` so suporta `build`, `setup`, `clean` e `help`.
-- Atualizar docs para separar claramente `v1.0-rc2` implementado de M8 planejado.
+- Atualizar docs para separar claramente `v1.0.0-rc.2` implementado de M8 planejado.
 - Remover das docs de configuracao qualquer afirmacao de que `SENTINEL_LLM_*`, `LLM_PROVIDER`, `OLLAMA_*`, Gemini/OpenAI ou Ollama ativam funcionalidade hoje.
 - Manter M8 como backlog provider-agnostic: cloud LLM futuro, contrato final ainda TBD, sem LLM local.
 
 3. LLM package alignment
 - Ajustar `agent/pkg/llm` para nao expor Ollama como provider funcional.
-- Manter apenas a interface/fachada minima para futuro M8, sempre disabled em `v1.0-rc2`.
+- Manter apenas a interface/fachada minima para futuro M8, sempre disabled em `v1.0.0-rc.2`.
 - Atualizar testes de `pkg/llm` para cobrir: default disabled, provider/env desconhecido nao ativa, nenhuma dependencia de `OLLAMA_ENDPOINT` ou `OLLAMA_MODEL`.
 
 4. Helm hardening
-- Atualizar `helm/sentinel/Chart.yaml` para versao/appVersion coerentes com `1.0-rc2`.
+- Atualizar `helm/sentinel/Chart.yaml` para versao/appVersion coerentes com `1.0.0-rc.2`.
 - Atualizar `helm/sentinel/values.yaml`: imagem default para GHCR, tag coerente com RC, `pullPolicy: IfNotPresent`.
 - Remover `database.password: sentinel123`; deixar vazio e exigir valor no template com `required`.
 - Limpar ruido estrutural: remover `ons: []` e duplicidade de `affinity`.
@@ -46,7 +46,7 @@ Decisoes fechadas:
 - Setup local usa `.env.example` na raiz, nao `agent/.env.example`.
 - Comandos documentados refletem o Makefile real: `make build`, `make setup`, `make clean`, `make help`.
 - Helm install exige explicitamente `--set agent.auth.token=<secret>` e `--set database.password=<secret>`.
-- Nenhuma variavel LLM e documentada como funcional em `v1.0-rc2`.
+- Nenhuma variavel LLM e documentada como funcional em `v1.0.0-rc.2`.
 - `X-Real-IP` deixa de influenciar rate limit; `RemoteAddr` e a unica fonte.
 
 ## Test Plan
@@ -60,6 +60,6 @@ Decisoes fechadas:
 ## Assumptions
 
 - Nao implementar cloud LLM nesta rodada; isso permanece para M8.
-- Nao adicionar trusted proxies agora; a solucao de v1.0-rc2 e simples e segura: `RemoteAddr only`.
+- Nao adicionar trusted proxies agora; a solucao de v1.0.0-rc.2 e simples e segura: `RemoteAddr only`.
 - Nao mexer no OpenAPI salvo se alguma API publica mudar.
 - Nao alterar os arquivos staged preexistentes fora do necessario.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="docs/screenshots/sentinel_ss_1.0-rc(1).png" alt="Sentinel Dashboard v1.0" width="900"/>
 </p>
 
-![Status](https://img.shields.io/badge/status-v1.0--rc2-brightgreen)
+![Status](https://img.shields.io/badge/status-v1.0.0--rc.2-brightgreen)
 ![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.35.1-blue)
 ![Go](https://img.shields.io/badge/Go-1.25-00ADD8)
 ![Standalone](https://img.shields.io/badge/standalone-no%20Prometheus-green)
@@ -147,7 +147,7 @@ Operational release notes are maintained in [RELEASE.md](RELEASE.md).
 
 The current support matrix is published in [docs/support-matrix.md](docs/support-matrix.md).
 
-| Category | v1.0-rc2 status |
+| Category | v1.0.0-rc.2 status |
 |---|---|
 | Supported | Kubernetes `v1.19+`, Helm 3, PostgreSQL 15, Metrics Server, deterministic rules |
 | Tested | Go unit tests, harness safety tests, Helm lint, chaos lab and capacity planning reports |
@@ -179,7 +179,7 @@ DB_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
 # Assumes the TLS secret already exists and your ingress controller is installed.
 helm install sentinel helm/sentinel -n sentinel --create-namespace \
   --set image.repository=ghcr.io/boccato85/sentinel \
-  --set image.tag=1.0-rc2 \
+  --set image.tag=1.0.0-rc.2 \
   --set agent.auth.token=$AUTH_TOKEN \
   --set database.password=$DB_PASSWORD \
   --set ingress.enabled=true \
@@ -487,7 +487,7 @@ Every final report passes through `harness/output_validator.py` before being wri
 
 ## Changelog
 
-### v1.0-rc2 — Release-readiness hardening
+### v1.0.0-rc.2 — Release-readiness hardening
 - **Docs/runtime alignment** — setup paths now use root `.env.example`; agent management docs match the real Makefile targets.
 - **Helm hardening** — GHCR image defaults, explicit database password requirement and cleaned `values.yaml` structure.
 - **Production-first deploy** — chart defaults to `ClusterIP`, adds Ingress rendering and documents NodePort as dev/lab only.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,10 @@
-# Sentinel v1.0-rc2 Release Notes
+# Sentinel v1.0.0-rc.2 Release Notes
 
 Release date: 2026-04-23
 
 ## Operational Summary
 
-`v1.0-rc2` is a release-readiness hardening candidate. It focuses on consistent versioning, secure-by-default Helm installation, production-first exposure guidance and clearer v1.0 support boundaries.
+`v1.0.0-rc.2` is a release-readiness hardening candidate. It focuses on consistent versioning, secure-by-default Helm installation, production-first exposure guidance and clearer v1.0 support boundaries.
 
 ## Breaking / Operator-Visible Changes
 
@@ -35,7 +35,7 @@ helm install sentinel helm/sentinel -n sentinel --create-namespace \
 ```bash
 helm upgrade sentinel helm/sentinel -n sentinel \
   --reuse-values \
-  --set image.tag=1.0-rc2 \
+  --set image.tag=1.0.0-rc.2 \
   --set agent.auth.token="$AUTH_TOKEN" \
   --set database.password="$DB_PASSWORD"
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Sentinel Roadmap — 0.x → 1.0
 
-> Last updated: 2026-04-23 | Current version: `v1.0-rc1`
+> Last updated: 2026-04-23 | Current version: `v1.0.0-rc.2`
 
 ## Product vision
 
@@ -34,6 +34,8 @@
 | M6 — Real lab / QA / Prod-like | ✅ Done | `v0.50` |
 | M7 — v1.0 preparation | ✅ Done | `v1.0-rc1` |
 | M8 — Sentinel Intelligence (cloud LLM + agentic) | 🔵 Planned | `v1.1` |
+
+> Release-readiness hardening for `v1.0.0-rc.2` is tracked in the GitHub Project "Sentinel v1.0 Release Readiness" and covers version alignment, ingress-first deploy, support matrix, release notes and quality evidence.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We aim to acknowledge reports within 48 hours and release a fix within 14 days d
 
 | Version | Supported |
 |---|---|
-| `v1.0-rc2` (current) | ✅ Yes |
+| `v1.0.0-rc.2` (current) | ✅ Yes |
 | `v0.50.x` | ❌ No — upgrade to v1.0 |
 | `< v0.50` | ❌ No |
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -31,7 +31,7 @@ var (
 	usdPerGbHour   float64
 )
 
-const agentVersion = "1.0-rc2"
+const agentVersion = "1.0.0-rc.2"
 const collectorStaleThreshold = 30 * time.Second
 
 var (

--- a/agent/pkg/api/openapi.yaml
+++ b/agent/pkg/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Sentinel Agent API
   description: Sentinel is an SRE/FinOps intelligence agent for small teams running Kubernetes.
-  version: 1.0-rc2
+  version: 1.0.0-rc.2
 servers:
   - url: http://localhost:30080
     description: Local or NodePort development

--- a/agent/pkg/llm/client_test.go
+++ b/agent/pkg/llm/client_test.go
@@ -5,10 +5,10 @@ import "testing"
 func TestNewClient_NoProvider(t *testing.T) {
 	c := NewClient()
 	if c.Enabled {
-		t.Error("expected Enabled=false in v1.0-rc2")
+		t.Error("expected Enabled=false in v1.0.0-rc.2")
 	}
 	if c.ActiveProvider != nil {
-		t.Error("expected ActiveProvider=nil in v1.0-rc2")
+		t.Error("expected ActiveProvider=nil in v1.0.0-rc.2")
 	}
 }
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Sentinel Agent API
   description: Sentinel is an SRE/FinOps intelligence agent for small teams running Kubernetes.
-  version: 1.0-rc2
+  version: 1.0.0-rc.2
 servers:
   - url: http://localhost:30080
     description: Local or NodePort development

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,6 +1,6 @@
 # Sentinel Support Matrix
 
-This matrix applies to Sentinel `v1.0-rc2`.
+This matrix applies to Sentinel `v1.0.0-rc.2`.
 
 ## Supported
 

--- a/helm/sentinel/Chart.yaml
+++ b/helm/sentinel/Chart.yaml
@@ -3,7 +3,7 @@ name: sentinel
 description: Standalone Kubernetes observability and FinOps platform with real-time dashboard
 type: application
 version: "1.0.0-rc.2"
-appVersion: "1.0-rc2"
+appVersion: "1.0.0-rc.2"
 keywords:
   - kubernetes
   - observability

--- a/helm/sentinel/values.yaml
+++ b/helm/sentinel/values.yaml
@@ -6,7 +6,7 @@ timezone: "America/Sao_Paulo"
 
 image:
   repository: ghcr.io/boccato85/sentinel
-  tag: "1.0-rc2"
+  tag: "1.0.0-rc.2"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Align all public version surfaces to the same SemVer string (v1.0.0-rc.2).

- Update agent version, Helm appVersion/image tag, docs and OpenAPI mirror.
- Keep OpenAPI versions synchronized.

Closes #19.