### PR TITLE
fix(security): remove insecure local defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,23 @@
-# CloudWatch Sentinel — Environment Variables
-# Copy this file to .env and fill in your values:
+# Sentinel — Environment Variables
+# Copy this file to .env and set strong values:
 #   cp .env.example .env
 #
 # .env is gitignored and will never be committed.
+#
+# Generate secrets:
+#   python3 -c "import secrets; print(secrets.token_urlsafe(32))"   # DB_PASSWORD
+#   python3 -c "import secrets; print(secrets.token_hex(32))"       # AUTH_TOKEN
 
 # PostgreSQL credentials (required)
 DB_USER=sentinel
-DB_PASSWORD=change-me
+DB_PASSWORD=
 
 # PostgreSQL connection (optional — defaults shown)
 DB_NAME=sentinel_db
 DB_HOST=localhost
 DB_PORT=5432
-DB_SSLMODE=disable   # use "require" for production
+DB_SSLMODE=disable   # set to "require" when using TLS
 
 # API authentication (required when AUTH_ENABLED=true)
 AUTH_ENABLED=true
-AUTH_TOKEN=change-me
+AUTH_TOKEN=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Thank you for your interest in contributing. Sentinel is a focused SRE/FinOps to
 ```bash
 git clone https://github.com/boccato85/Sentinel
 cd Sentinel
-cp .env.example .env   # fill DB_PASSWORD and AUTH_TOKEN
+cp .env.example .env   # fill DB_PASSWORD and AUTH_TOKEN (no defaults)
 docker compose up --build
 # Dashboard: http://localhost:8080/?token=<AUTH_TOKEN>
 ```

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Requires a kubeconfig at `~/.kube/config` pointing to your cluster. Without a cl
 
 ```bash
 # Requires local PostgreSQL with database sentinel_db
-export DB_USER=postgres
-export DB_PASSWORD=postgres
+export DB_USER=<your-postgres-user>
+export DB_PASSWORD=<your-postgres-password>
 export DB_NAME=sentinel_db
 export DB_HOST=localhost
 export DB_SSLMODE=disable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
     environment:
       POSTGRES_DB: sentinel_db
       POSTGRES_USER: ${DB_USER:-sentinel}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      # Fail fast if secrets are missing (prevents running with empty/weak defaults).
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required. Copy .env.example to .env and set it}
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
@@ -38,10 +39,10 @@ services:
       DB_PORT: "5432"
       DB_NAME: sentinel_db
       DB_USER: ${DB_USER:-sentinel}
-      DB_PASSWORD: ${DB_PASSWORD}
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required. Copy .env.example to .env and set it}
       DB_SSLMODE: disable
       AUTH_ENABLED: "true"
-      AUTH_TOKEN: ${AUTH_TOKEN}
+      AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required. Copy .env.example to .env and set it}
       LISTEN_ADDR: "0.0.0.0:8080"
       THRESHOLDS_PATH: /app/config/thresholds.yaml
       LOG_LEVEL: ${LOG_LEVEL:-info}


### PR DESCRIPTION
Closes #20\n\nChanges:\n- Remove usable placeholder secrets from .env.example\n- Fail fast in docker-compose when DB_PASSWORD/AUTH_TOKEN are missing\n- Remove insecure standalone example password in README\n