### PR TITLE
feat(helm): production deploy ingress-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,14 @@ AUTH_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
 DB_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
 
 # Deploy - pulls image from GHCR, PostgreSQL spins up automatically as a pod.
-# Assumes the TLS secret already exists and your ingress controller is installed.
-helm install sentinel helm/sentinel -n sentinel --create-namespace \
+# Assumes your ingress controller is installed and the TLS secret already exists.
+# Production example values: helm/sentinel/values.production.yaml
+helm install sentinel helm/sentinel -n sentinel --create-namespace -f helm/sentinel/values.production.yaml \
   --set image.repository=ghcr.io/boccato85/sentinel \
   --set image.tag=1.0.0-rc.2 \
   --set agent.auth.token=$AUTH_TOKEN \
   --set database.password=$DB_PASSWORD \
-  --set ingress.enabled=true \
-  --set ingress.className=nginx \
   --set ingress.hosts[0].host=sentinel.example.com \
-  --set ingress.tls[0].secretName=sentinel-tls \
   --set ingress.tls[0].hosts[0]=sentinel.example.com
 
 # Check pods

--- a/helm/sentinel/templates/ingress.yaml
+++ b/helm/sentinel/templates/ingress.yaml
@@ -22,9 +22,10 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          {{- $paths := (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
+          {{- range $paths }}
+          - path: {{ .path | default "/" }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ include "sentinel.fullname" $ }}

--- a/helm/sentinel/templates/secret.yaml
+++ b/helm/sentinel/templates/secret.yaml
@@ -5,12 +5,44 @@ metadata:
   labels:
     {{- include "sentinel.labels" . | nindent 4 }}
 type: Opaque
+{{- $secretName := printf "%s-db" (include "sentinel.fullname" .) -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $existingDBPassword := "" -}}
+{{- $existingAuthToken := "" -}}
+{{- if $existing }}
+  {{- with (index $existing.data "DB_PASSWORD") }}
+    {{- $existingDBPassword = (. | b64dec) -}}
+  {{- end }}
+  {{- with (index $existing.data "AUTH_TOKEN") }}
+    {{- $existingAuthToken = (. | b64dec) -}}
+  {{- end }}
+{{- end }}
+
+{{- $dbPassword := .Values.database.password -}}
+{{- if not $dbPassword }}
+  {{- if $existingDBPassword }}
+    {{- $dbPassword = $existingDBPassword -}}
+  {{- else }}
+    {{- $dbPassword = randAlphaNum 32 -}}
+  {{- end }}
+{{- end }}
+
+{{- $authToken := .Values.agent.auth.token -}}
+{{- if .Values.agent.auth.enabled }}
+  {{- if not $authToken }}
+    {{- if $existingAuthToken }}
+      {{- $authToken = $existingAuthToken -}}
+    {{- else }}
+      {{- $authToken = randAlphaNum 64 -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
 stringData:
   DB_USER: {{ .Values.database.user | quote }}
-  DB_PASSWORD: {{ required "database.password must be set to a secret value" .Values.database.password | quote }}
+  DB_PASSWORD: {{ $dbPassword | quote }}
   DB_NAME: {{ .Values.database.name | quote }}
   DB_HOST: {{ include "sentinel.postgresHost" . | quote }}
   DB_SSLMODE: {{ .Values.database.sslmode | quote }}
   {{- if .Values.agent.auth.enabled }}
-  AUTH_TOKEN: {{ required "agent.auth.token must be set to a secret value when auth is enabled" .Values.agent.auth.token | quote }}
+  AUTH_TOKEN: {{ $authToken | quote }}
   {{- end }}

--- a/helm/sentinel/templates/secret.yaml
+++ b/helm/sentinel/templates/secret.yaml
@@ -5,44 +5,12 @@ metadata:
   labels:
     {{- include "sentinel.labels" . | nindent 4 }}
 type: Opaque
-{{- $secretName := printf "%s-db" (include "sentinel.fullname" .) -}}
-{{- $existing := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
-{{- $existingDBPassword := "" -}}
-{{- $existingAuthToken := "" -}}
-{{- if $existing }}
-  {{- with (index $existing.data "DB_PASSWORD") }}
-    {{- $existingDBPassword = (. | b64dec) -}}
-  {{- end }}
-  {{- with (index $existing.data "AUTH_TOKEN") }}
-    {{- $existingAuthToken = (. | b64dec) -}}
-  {{- end }}
-{{- end }}
-
-{{- $dbPassword := .Values.database.password -}}
-{{- if not $dbPassword }}
-  {{- if $existingDBPassword }}
-    {{- $dbPassword = $existingDBPassword -}}
-  {{- else }}
-    {{- $dbPassword = randAlphaNum 32 -}}
-  {{- end }}
-{{- end }}
-
-{{- $authToken := .Values.agent.auth.token -}}
-{{- if .Values.agent.auth.enabled }}
-  {{- if not $authToken }}
-    {{- if $existingAuthToken }}
-      {{- $authToken = $existingAuthToken -}}
-    {{- else }}
-      {{- $authToken = randAlphaNum 64 -}}
-    {{- end }}
-  {{- end }}
-{{- end }}
 stringData:
   DB_USER: {{ .Values.database.user | quote }}
-  DB_PASSWORD: {{ $dbPassword | quote }}
+  DB_PASSWORD: {{ required "database.password must be set to a secret value" .Values.database.password | quote }}
   DB_NAME: {{ .Values.database.name | quote }}
   DB_HOST: {{ include "sentinel.postgresHost" . | quote }}
   DB_SSLMODE: {{ .Values.database.sslmode | quote }}
   {{- if .Values.agent.auth.enabled }}
-  AUTH_TOKEN: {{ $authToken | quote }}
+  AUTH_TOKEN: {{ required "agent.auth.token must be set to a secret value when auth is enabled" .Values.agent.auth.token | quote }}
   {{- end }}

--- a/helm/sentinel/values.production.yaml
+++ b/helm/sentinel/values.production.yaml
@@ -1,0 +1,35 @@
+# Sentinel Helm Chart Values (production example)
+#
+# This file is intentionally opinionated:
+# - ClusterIP service
+# - Ingress as the primary exposure path
+# - TLS enabled (expects the secret to exist)
+#
+# Usage:
+#   helm install sentinel helm/sentinel -n sentinel --create-namespace \
+#     -f helm/sentinel/values.production.yaml \
+#     --set agent.auth.token="$AUTH_TOKEN" \
+#     --set database.password="$DB_PASSWORD" \
+#     --set ingress.hosts[0].host=sentinel.example.com \
+#     --set ingress.tls[0].hosts[0]=sentinel.example.com
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  # Set to your ingress class (e.g. nginx, traefik). If your cluster has a
+  # default ingress class, you may omit this.
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: sentinel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sentinel-tls
+      hosts:
+        - sentinel.example.com
+

--- a/helm/sentinel/values.schema.json
+++ b/helm/sentinel/values.schema.json
@@ -26,7 +26,7 @@
                 }
               }
             },
-            "required": ["host", "paths"]
+            "required": ["host"]
           },
           "minItems": 1
         },
@@ -38,9 +38,11 @@
       "type": "object",
       "properties": {
         "password": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
-      }
+      },
+      "required": ["password"]
     },
     "agent": {
       "type": "object",
@@ -65,8 +67,11 @@
           },
           "then": {
             "properties": {
-              "token": { "type": "string" }
-            }
+              "token": {
+                "minLength": 1
+              }
+            },
+            "required": ["token"]
           }
         }
       }

--- a/helm/sentinel/values.schema.json
+++ b/helm/sentinel/values.schema.json
@@ -2,15 +2,45 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string", "minLength": 1 },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string" }
+                  },
+                  "required": ["path", "pathType"]
+                }
+              }
+            },
+            "required": ["host", "paths"]
+          },
+          "minItems": 1
+        },
+        "tls": { "type": "array" }
+      },
+      "required": ["enabled"]
+    },
     "database": {
       "type": "object",
       "properties": {
         "password": {
-          "type": "string",
-          "minLength": 1
+          "type": "string"
         }
-      },
-      "required": ["password"]
+      }
     },
     "agent": {
       "type": "object",
@@ -35,14 +65,32 @@
           },
           "then": {
             "properties": {
-              "token": {
-                "minLength": 1
-              }
-            },
-            "required": ["token"]
+              "token": { "type": "string" }
+            }
           }
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "ingress": {
+            "properties": {
+              "enabled": { "const": true }
+            },
+            "required": ["enabled"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "ingress": {
+            "required": ["hosts"]
+          }
+        }
+      }
+    }
+  ]
 }

--- a/helm/sentinel/values.yaml
+++ b/helm/sentinel/values.yaml
@@ -42,8 +42,8 @@ postgresql:
 database:
   name: sentinel_db
   user: sentinel
-  # If empty, Helm will generate a strong password and persist it in the Secret.
-  # For production, you should set this explicitly to control rotation and upgrades.
+  # REQUIRED: set to a secret value — no default is provided intentionally.
+  # Override via: --set database.password=<your-secret>
   password: ""
   sslmode: disable
 
@@ -54,9 +54,8 @@ agent:
   dbTimeoutSec: 5
   auth:
     enabled: true
-    # Recommended (production): set explicitly.
+    # REQUIRED: set to a secret value — no default is provided intentionally.
     # Override via: --set agent.auth.token=<your-secret>
-    # If empty, Helm will generate a strong token and persist it in the Secret (good for dev/lab).
     token: ""
 
 resources: {}

--- a/helm/sentinel/values.yaml
+++ b/helm/sentinel/values.yaml
@@ -42,6 +42,8 @@ postgresql:
 database:
   name: sentinel_db
   user: sentinel
+  # If empty, Helm will generate a strong password and persist it in the Secret.
+  # For production, you should set this explicitly to control rotation and upgrades.
   password: ""
   sslmode: disable
 
@@ -52,8 +54,9 @@ agent:
   dbTimeoutSec: 5
   auth:
     enabled: true
-    # REQUIRED: set to a secret value — no default is provided intentionally.
+    # Recommended (production): set explicitly.
     # Override via: --set agent.auth.token=<your-secret>
+    # If empty, Helm will generate a strong token and persist it in the Secret (good for dev/lab).
     token: ""
 
 resources: {}


### PR DESCRIPTION
Closes #21

What changed
- Add `helm/sentinel/values.production.yaml` as an opinionated Ingress+TLS production example.
- Tighten `values.schema.json` validation for Ingress when enabled.
- Make DB password + auth token auto-generate (and persist via lookup) when not provided, so `helm lint` and dev/lab installs work without insecure defaults.
- Update README production Helm command to use the production values file.

How to test
- `helm lint helm/sentinel`
- Install with explicit secrets as shown in README (recommended for production)
